### PR TITLE
Update dwm-awesomebar-fix.diff

### DIFF
--- a/dwm-awesomebar-fix.diff
+++ b/dwm-awesomebar-fix.diff
@@ -436,8 +436,8 @@ index a96f33c..c375ba3 100644
 +togglewin(const Arg *arg)
 +{
 +	Client *c = (Client*)arg->v;
-+ if (!c)
-+  return;
++	if (!c)
++		return;
 +
 +	if (c == selmon->sel) {
 +		hidewin(c);

--- a/dwm-awesomebar-fix.diff
+++ b/dwm-awesomebar-fix.diff
@@ -436,6 +436,8 @@ index a96f33c..c375ba3 100644
 +togglewin(const Arg *arg)
 +{
 +	Client *c = (Client*)arg->v;
++ if (!c)
++  return;
 +
 +	if (c == selmon->sel) {
 +		hidewin(c);


### PR DESCRIPTION
Hotfix for crash when clicking on empty status bar.